### PR TITLE
Fix crash when passing null to highlightedFileName 

### DIFF
--- a/open_dir_linux/CHANGELOG.md
+++ b/open_dir_linux/CHANGELOG.md
@@ -1,15 +1,19 @@
-## 0.0.1
+## 0.0.2+1
 
-* Initial Linux plugin
+* Fix assertion error when passing null to highlightedFileName
 
-## 0.0.1+1
+## 0.0.2
 
-* Fixes app-facing package run on linux platform
+* Support to open dir with highlighted file
 
 ## 0.0.1+2
 
 * Change Dart SDK range
 
-## 0.0.2
+## 0.0.1+1
 
-* Support to open dir with highlighted file
+* Fixes app-facing package run on linux platform
+
+## 0.0.1
+
+* Initial Linux plugin

--- a/open_dir_linux/linux/open_dir_linux_plugin.cc
+++ b/open_dir_linux/linux/open_dir_linux_plugin.cc
@@ -75,7 +75,7 @@ static void open_dir_get_args(FlMethodCall *method_call, gchar **path, gchar **h
   *path = g_strdup(fl_value_get_string(path_value));
   
   FlValue *highlighted_file_value = fl_value_lookup_string(args, "highlightedFileName");
-  if (highlighted_file_value != nullptr)
+  if (highlighted_file_value != nullptr && fl_value_get_type(highlighted_file_value) == FL_VALUE_TYPE_STRING)
   {
     *highlighted_file = g_strdup(fl_value_get_string(highlighted_file_value));
   }

--- a/open_dir_linux/pubspec.yaml
+++ b/open_dir_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: open_dir_linux
 description: Linux implementation of the open_dir plugin
 repository: https://github.com/huynguyennovem/open_dir/tree/main/open_dir_linux
 issue_tracker: https://github.com/huynguyennovem/open_dir/issues
-version: 0.0.2
+version: 0.0.2+1
 
 environment:
   sdk: '>=2.18.0 <4.0.0'
@@ -25,5 +25,3 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^2.0.0
-#  open_dir_platform_interface:
-#    path: ../open_dir_platform_interface

--- a/open_dir_windows/CHANGELOG.md
+++ b/open_dir_windows/CHANGELOG.md
@@ -1,20 +1,24 @@
-## 0.0.1
+## 0.0.2+1
 
-* Initial Windows plugin
+* Fix crash when passing null to highlightedFileName
+
+## 0.0.2
+
+* Support to open dir with highlighted file
+
+## 0.0.1+3
+
+* Fixed a bug where a folder could not be opened if the path contained Chinese characters
+
+## 0.0.1+2
+
+* Change Dart SDK range
 
 ## 0.0.1+1
 
 * Fix plugin config
 * Fixes app-facing package run on windows platform
 
-## 0.0.1+2
+## 0.0.1
 
-* Change Dart SDK range
-
-## 0.0.1+3
-
-* Fixed a bug where a folder could not be opened if the path contained Chinese characters
-
-## 0.0.2
-
-* Support to open dir with highlighted file
+* Initial Windows plugin

--- a/open_dir_windows/pubspec.yaml
+++ b/open_dir_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: open_dir_windows
 description: Windows implementation of the open_dir plugin
 repository: https://github.com/huynguyennovem/open_dir/tree/main/open_dir_windows
 issue_tracker: https://github.com/huynguyennovem/open_dir/issues
-version: 0.0.2
+version: 0.0.2+1
 
 environment:
   sdk: '>=2.18.0 <4.0.0'
@@ -25,5 +25,3 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^2.0.0
-#  open_dir_platform_interface:
-#    path: ../open_dir_platform_interface

--- a/open_dir_windows/windows/open_dir_windows_plugin.cpp
+++ b/open_dir_windows/windows/open_dir_windows_plugin.cpp
@@ -50,7 +50,7 @@ static std::wstring Utf8ToWide(const std::string& str) {
     return wstrTo;
 }
 
-static bool OpenDir(const std::string& path, const std::string& highlightedFileName = "") {
+static bool OpenDir(const std::string& path, const std::string highlightedFileName = "") {
     std::wstring wpath = Utf8ToWide(path);
     
     HINSTANCE result;
@@ -69,8 +69,13 @@ std::string GetStringArgument(const flutter::MethodCall<>& method_call, const st
     const auto* arguments = std::get_if<EncodableMap>(method_call.arguments());
     if (arguments) {
         auto it = arguments->find(EncodableValue(key));
-        if (it != arguments->end()) {
-            value = std::get<std::string>(it->second);
+        if (it != arguments->end() && !it->second.IsNull()) {
+            try {
+                value = std::get<std::string>(it->second);
+            } catch (const std::bad_variant_access&) {
+                // Handle conversion error gracefully
+                value = "";
+            }
         }
     }
     return value;

--- a/open_dir_windows/windows/open_dir_windows_plugin.cpp
+++ b/open_dir_windows/windows/open_dir_windows_plugin.cpp
@@ -73,7 +73,6 @@ std::string GetStringArgument(const flutter::MethodCall<>& method_call, const st
             try {
                 value = std::get<std::string>(it->second);
             } catch (const std::bad_variant_access&) {
-                // Handle conversion error gracefully
                 value = "";
             }
         }


### PR DESCRIPTION
When passing null to highlightedFileName, causes crash on Windows and assertion on Linux

Fixes https://github.com/huynguyennovem/open_dir/issues/12